### PR TITLE
Add option to disable scheduled refresh

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -38,6 +38,14 @@ type OAuth2FetchOptions = {
    */
   getStoredToken?: () => OAuth2Token | null | Promise<OAuth2Token | null>;
 
+  /**
+   * Whether to automatically schedule token refresh.
+   *
+   * Certain execution environments, e.g. React Native, do not handle scheduled
+   * tasks with setTimeout() in a graceful or predictable fashion. The default
+   * behavior is to schedule refresh. Set this to false to disable scheduling.
+   */
+  scheduleRefresh?: boolean;
 }
 
 
@@ -54,6 +62,9 @@ export class OAuth2Fetch {
 
   constructor(options: OAuth2FetchOptions) {
 
+    if (options?.scheduleRefresh === undefined) {
+      options.scheduleRefresh = true;
+    }
     this.options = options;
     if (options.getStoredToken) {
       (async () => {
@@ -222,7 +233,9 @@ export class OAuth2Fetch {
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
 
   private scheduleRefresh() {
-
+    if (!this.options.scheduleRefresh) {
+      return;
+    }
     if (this.refreshTimer) {
       clearTimeout(this.refreshTimer);
       this.refreshTimer = null;


### PR DESCRIPTION
Thanks for this excellent little library.

I am using this in a React Native project, and `setTimeout()` isn't really advisable in that context/doesn't make as much sense as it may in say, a browser. See https://github.com/facebook/react-native/issues/12981#issuecomment-652745831 for further.

This PR adds a configuration option to disable scheduling a refresh.

I am not a JavaScript developer and this is literally the first TypeScript I've written, so please be gentle. I've tested locally but I am only running in the context of tokens obtained outside of this middleware... so take a close look in review.