### PR TITLE
Add support for client_secret_post auth method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -33,7 +33,7 @@ export interface ClientSettings {
   /**
    * OAuth2 clientSecret
    *
-   * This is required when using the 'client_secret_basic' authenticationMethod 
+   * This is required when using the 'client_secret_basic' authenticationMethod
    * for the client_credentials and password flows, but not authorization_code
    * or implicit.
    */
@@ -73,11 +73,11 @@ export interface ClientSettings {
   discoveryEndpoint?: string;
 
   /**
-   * Client authentication method that is used to authenticate 
+   * Client authentication method that is used to authenticate
    * when using the token endpoint.
-   * 
+   *
    * Can be one of 'client_secret_basic' | 'client_secret_post'.
-   * 
+   *
    * The default value is 'client_secret_basic' if not provided.
    */
   authenticationMethod?: string;
@@ -94,7 +94,7 @@ export class OAuth2Client {
 
     this.settings = clientSettings;
     if (!this.settings.authenticationMethod) {
-      this.settings.authenticationMethod = 'client_secret_basic'
+      this.settings.authenticationMethod = 'client_secret_basic';
     }
   }
 

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 describe('client-credentials', () => {
 
-  it('should work', async() => {
+  it('should work with client_secret_basic', async () => {
 
     const server = testServer();
 
@@ -27,6 +27,34 @@ describe('client-credentials', () => {
 
     expect(request.body).to.eql({
       grant_type: 'client_credentials',
+    });
+  });
+
+  it('should work with client_secret_post', async () => {
+
+    const server = testServer();
+
+    const client = new OAuth2Client({
+      server: server.url,
+      tokenEndpoint: '/token',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      authenticationMethod: 'client_secret_post'
+    });
+
+    const result = await client.clientCredentials();
+
+    expect(result.accessToken).to.equal('access_token_000');
+    expect(result.refreshToken).to.equal('refresh_token_000');
+    expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+    expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+    const request = server.lastRequest();
+
+    expect(request.body).to.eql({
+      client_id: "test-client-id",
+      client_secret: "test-client-secret",
+      grant_type: 'client_credentials'
     });
   });
 

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -52,8 +52,8 @@ describe('client-credentials', () => {
     const request = server.lastRequest();
 
     expect(request.body).to.eql({
-      client_id: "test-client-id",
-      client_secret: "test-client-secret",
+      client_id: 'test-client-id',
+      client_secret: 'test-client-secret',
       grant_type: 'client_credentials'
     });
   });

--- a/test/password.ts
+++ b/test/password.ts
@@ -1,0 +1,69 @@
+import { testServer } from './test-server';
+import { OAuth2Client } from '../src';
+import { expect } from 'chai';
+
+describe('password', () => {
+
+    it('should work with client_secret_basic', async () => {
+
+        const server = testServer();
+
+        const client = new OAuth2Client({
+            server: server.url,
+            tokenEndpoint: '/token',
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+        });
+
+        const result = await client.password({
+            username: 'user123',
+            password: 'password'
+        });
+
+        expect(result.accessToken).to.equal('access_token_000');
+        expect(result.refreshToken).to.equal('refresh_token_000');
+        expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+        expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+        const request = server.lastRequest();
+        expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
+
+        expect(request.body).to.eql({
+            grant_type: 'password',
+            password: "password",
+            username: "user123"
+        });
+    });
+
+    it('should work with client_secret_post', async () => {
+
+        const server = testServer();
+
+        const client = new OAuth2Client({
+            server: server.url,
+            tokenEndpoint: '/token',
+            clientId: 'test-client-id',
+            authenticationMethod: 'client_secret_post'
+        });
+
+        const result = await client.password({
+            username: 'user123',
+            password: 'password'
+        });
+
+        expect(result.accessToken).to.equal('access_token_000');
+        expect(result.refreshToken).to.equal('refresh_token_000');
+        expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+        expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+        const request = server.lastRequest();
+
+        expect(request.body).to.eql({
+            grant_type: 'password',
+            password: "password",
+            username: "user123",
+            client_id: 'test-client-id'
+        });
+    });
+
+});

--- a/test/password.ts
+++ b/test/password.ts
@@ -4,66 +4,66 @@ import { expect } from 'chai';
 
 describe('password', () => {
 
-    it('should work with client_secret_basic', async () => {
+  it('should work with client_secret_basic', async () => {
 
-        const server = testServer();
+    const server = testServer();
 
-        const client = new OAuth2Client({
-            server: server.url,
-            tokenEndpoint: '/token',
-            clientId: 'test-client-id',
-            clientSecret: 'test-client-secret',
-        });
-
-        const result = await client.password({
-            username: 'user123',
-            password: 'password'
-        });
-
-        expect(result.accessToken).to.equal('access_token_000');
-        expect(result.refreshToken).to.equal('refresh_token_000');
-        expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
-        expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
-
-        const request = server.lastRequest();
-        expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
-
-        expect(request.body).to.eql({
-            grant_type: 'password',
-            password: "password",
-            username: "user123"
-        });
+    const client = new OAuth2Client({
+      server: server.url,
+      tokenEndpoint: '/token',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
     });
 
-    it('should work with client_secret_post', async () => {
-
-        const server = testServer();
-
-        const client = new OAuth2Client({
-            server: server.url,
-            tokenEndpoint: '/token',
-            clientId: 'test-client-id',
-            authenticationMethod: 'client_secret_post'
-        });
-
-        const result = await client.password({
-            username: 'user123',
-            password: 'password'
-        });
-
-        expect(result.accessToken).to.equal('access_token_000');
-        expect(result.refreshToken).to.equal('refresh_token_000');
-        expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
-        expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
-
-        const request = server.lastRequest();
-
-        expect(request.body).to.eql({
-            grant_type: 'password',
-            password: "password",
-            username: "user123",
-            client_id: 'test-client-id'
-        });
+    const result = await client.password({
+      username: 'user123',
+      password: 'password'
     });
+
+    expect(result.accessToken).to.equal('access_token_000');
+    expect(result.refreshToken).to.equal('refresh_token_000');
+    expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+    expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+    const request = server.lastRequest();
+    expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
+
+    expect(request.body).to.eql({
+      grant_type: 'password',
+      password: 'password',
+      username: 'user123'
+    });
+  });
+
+  it('should work with client_secret_post', async () => {
+
+    const server = testServer();
+
+    const client = new OAuth2Client({
+      server: server.url,
+      tokenEndpoint: '/token',
+      clientId: 'test-client-id',
+      authenticationMethod: 'client_secret_post'
+    });
+
+    const result = await client.password({
+      username: 'user123',
+      password: 'password'
+    });
+
+    expect(result.accessToken).to.equal('access_token_000');
+    expect(result.refreshToken).to.equal('refresh_token_000');
+    expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+    expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+    const request = server.lastRequest();
+
+    expect(request.body).to.eql({
+      grant_type: 'password',
+      password: 'password',
+      username: 'user123',
+      client_id: 'test-client-id'
+    });
+  });
 
 });


### PR DESCRIPTION
Adds support for `client_secret_post` authentication method for the `client_credentials` and `password` grants. This is useful for those who are unable to allow `client_secret_basic` on their auth server.

Tests have been added to assert correct behavior for:
- `client_secret_post` for `client_credentials` grant
- `client_secret_basic` for `password` grant
- `client_secret_post` for `password` grant

Additionally, I ran a formatter over the source files containing my changes, and fixed some typos.

---

Closes #85 