### PR TITLE
Allow specifying custom fetch

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -71,6 +71,14 @@ export interface ClientSettings {
    */
   discoveryEndpoint?: string;
 
+  /**
+   * Fetch implementation to use.
+   *
+   * Set this if you wish to explicitly set the fetch implementation, e.g. to
+   * implement middlewares or set custom headers.
+   */
+  fetch?: typeof fetch;
+
 }
 
 
@@ -82,6 +90,9 @@ export class OAuth2Client {
 
   constructor(clientSettings: ClientSettings) {
 
+    if (!clientSettings?.fetch) {
+      clientSettings.fetch = fetch;
+    }
     this.settings = clientSettings;
 
   }
@@ -229,7 +240,7 @@ export class OAuth2Client {
       console.warn('[oauth2] OAuth2 discovery endpoint could not be determined. Either specify the "server" or "discoveryEndpoint');
       return;
     }
-    const resp = await fetch(discoverUrl, { headers: { Accept: 'application/json' }});
+    const resp = await this.settings.fetch!(discoverUrl, { headers: { Accept: 'application/json' }});
     if (!resp.ok) return;
     if (!resp.headers.get('Content-Type')?.startsWith('application/json')) {
       console.warn('[oauth2] OAuth2 discovery endpoint was not a JSON response. Response is ignored');
@@ -272,7 +283,7 @@ export class OAuth2Client {
       body.client_id = this.settings.clientId;
     }
 
-    const resp = await fetch(uri, {
+    const resp = await this.settings.fetch!(uri, {
       method: 'POST',
       body: generateQueryString(body),
       headers,


### PR DESCRIPTION
You might want to transform the request going to the server, e.g. to add headers or manipulate the request. This provides a basic setting to specify a custom fetch function.

I'm not necessarily in love with the `typeof fetch` hint but if you're doing this, you should "know what you're doing"?