### PR TITLE
Add optional extraParams to clientCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ const fetchWrapper = new OAuth2Fetch({
 
   /**
    * You are responsible for implementing this function.
-   * it's purpose is to supply the 'intitial' oauth2 token.
+   * it's purpose is to supply the 'initial' oauth2 token.
    */
   getNewToken: async () => {
 
@@ -300,7 +300,7 @@ const fetchWrapper = new OAuth2Fetch({
 
   /**
    * Also an optional feature. Implement this if you want the wrapper to try a
-   * stored token before attempting a full reauthentication.
+   * stored token before attempting a full re-authentication.
    *
    * This function may be async. Return null if there was no token.
    */

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,7 @@ export interface ClientSettings {
    * The hostname of the OAuth2 server.
    * If provided, we'll attempt to discover all the other related endpoints.
    *
-   * If this is not desired, just specifiy the other endpoints manually.
+   * If this is not desired, just specify the other endpoints manually.
    *
    * This url will also be used as the base URL for all other urls. This lets
    * you specify all the other urls as relative.
@@ -56,7 +56,7 @@ export interface ClientSettings {
    * Introspection endpoint.
    *
    * Required for, well, introspecting tokens.
-   * If not provided we'll try to discover it, or othwerwise default to /introspect
+   * If not provided we'll try to discover it, or otherwise default to /introspect
    */
   introspectionEndpoint?: string;
 
@@ -152,7 +152,6 @@ export class OAuth2Client {
 
   /**
    * Returns the helper object for the `authorization_code` grant.
-   *
    */
   get authorizationCode(): OAuth2AuthorizationCodeClient {
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -111,12 +111,20 @@ export class OAuth2Client {
   /**
    * Retrieves an OAuth2 token using the client_credentials grant.
    */
-  async clientCredentials(params?: {scope?: string[]}): Promise<OAuth2Token> {
+  async clientCredentials(params?: { scope?: string[]; extraParams?: Record<string, string> }): Promise<OAuth2Token> {
 
-    const body:ClientCredentialsRequest = {
+    const disallowed = ['client_id', 'client_secret', 'grant_type', 'scope'];
+
+    if (params?.extraParams && Object.keys(params.extraParams).filter((key) => disallowed.includes(key)).length > 0) {
+      throw new Error(`The following extraParams are disallowed: '${disallowed.join("', '")}'`);
+    }
+
+    const body: ClientCredentialsRequest = {
       grant_type: 'client_credentials',
       scope: params?.scope?.join(' '),
+      ...params?.extraParams
     };
+
     if (!this.settings.clientSecret) {
       throw new Error('A clientSecret must be provided to use client_credentials');
     }

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -12,14 +12,14 @@ type OAuth2FetchOptions = {
 
   /**
    * You are responsible for implementing this function.
-   * it's purpose is to supply the 'intitial' oauth2 token.
+   * it's purpose is to supply the 'initial' oauth2 token.
    *
    * This function may be async. Return `null` to fail the process.
    */
   getNewToken(): OAuth2Token | null | Promise<OAuth2Token | null>;
 
   /**
-   * If set, will be called if authenticatin fatally failed.
+   * If set, will be called if authentication fatally failed.
    */
   onError?: (err: Error) => void;
 
@@ -32,7 +32,7 @@ type OAuth2FetchOptions = {
 
   /**
    * Also an optional feature. Implement this if you want the wrapper to try a
-   * stored token before attempting a full reauthentication.
+   * stored token before attempting a full re-authentication.
    *
    * This function may be async. Return null if there was no token.
    */
@@ -69,7 +69,7 @@ export class OAuth2Fetch {
    *
    * If the access token is not known, this function attempts to fetch it
    * first. If the access token is almost expiring, this function might attempt
-   1G* to refresh it.
+   * to refresh it.
    */
   async fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -15,6 +15,7 @@ export type RefreshRequest = {
 export type ClientCredentialsRequest = {
   grant_type: 'client_credentials';
   scope?: string;
+  [key: string]: string | undefined;
 }
 
 /**

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -109,7 +109,7 @@ export type ServerMetadataResponse = {
   /**
    * List of supported response types for the authorization endpoint.
    *
-   * If 'code' appears here it implies authoriziation_code support,
+   * If 'code' appears here it implies authorization_code support,
    * 'token' implies support for implicit auth.
    */
   response_types_supported: OAuth2ResponseType[];
@@ -158,12 +158,12 @@ export type ServerMetadataResponse = {
   op_tos_uri?: string;
 
   /**
-   * Url to servers revokation endpoint.
+   * Url to servers revocation endpoint.
    */
   revocation_endpoint?: string;
 
   /**
-   * Auth method that may be used on the revokation endpoint.
+   * Auth method that may be used on the revocation endpoint.
    */
   revocation_endpoint_auth_methods_supported?: OAuth2AuthMethod[];
 
@@ -189,7 +189,7 @@ export type ServerMetadataResponse = {
   introspection_endpoint_auth_signing_alg_values_supported?: string[];
 
   /**
-   * List of support PCKE code shallenge methods.
+   * List of support PCKE code challenge methods.
    */
   code_challenge_methods_supported?: OAuth2CodeChallengeMethod[];
 
@@ -209,7 +209,7 @@ export type IntrospectionResponse = {
   active: boolean;
 
   /**
-   * Space-separted list of scopes.
+   * Space-separated list of scopes.
    */
   scope?: string;
 


### PR DESCRIPTION
- Adds `extraParams` args to the `clientCredentials` method to support vendor-specific params
- Fixes some typos in code documentation

Fixes #90