### PR TITLE
Potential fix for #105

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -101,7 +101,7 @@ export class OAuth2Client {
   constructor(clientSettings: ClientSettings) {
 
     if (!clientSettings?.fetch) {
-      clientSettings.fetch = fetch;
+      clientSettings.fetch = fetch.bind(globalThis);
     }
     this.settings = clientSettings;
 


### PR DESCRIPTION
This binds fetch to `window` (or `global` depending on if it's in Node or a browser).

Fixes #105