### PR TITLE
Moved tokenResponseToOAuth2Token

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.2.3 (????-??-??)
+------------------
+
+* Moved the `tokenResponseToOAuth2Token` function inside the OAuth2Client
+  class, allowing users to override the parsing logic more easily.
+
+
 2.2.2 (2023-07-28)
 ------------------
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -125,7 +125,7 @@ export class OAuth2Client {
       body.client_id = this.settings.clientId;
     }
 
-    return tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
+    return this.tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
 
   }
 
@@ -150,7 +150,7 @@ export class OAuth2Client {
       throw new Error('A clientSecret must be provided to use client_credentials');
     }
 
-    return tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
+    return this.tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
 
   }
 
@@ -164,7 +164,7 @@ export class OAuth2Client {
       ...params,
       scope: params.scope?.join(' '),
     };
-    return tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
+    return this.tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
 
   }
 
@@ -350,21 +350,24 @@ export class OAuth2Client {
     throw new OAuth2Error(errorMessage, oauth2Code, resp.status);
   }
 
+  /**
+   * Converts the JSON response body from the token endpoint to an OAuth2Token type.
+   */
+  tokenResponseToOAuth2Token(resp: Promise<TokenResponse>): Promise<OAuth2Token> {
+
+    return resp.then(body => ({
+      accessToken: body.access_token,
+      expiresAt: body.expires_in ? Date.now() + (body.expires_in * 1000) : null,
+      refreshToken: body.refresh_token ?? null,
+    }));
+
+  }
+
 }
 
 function resolve(uri: string, base?: string): string {
 
   return new URL(uri, base).toString();
-
-}
-
-export function tokenResponseToOAuth2Token(resp: Promise<TokenResponse>): Promise<OAuth2Token> {
-
-  return resp.then(body => ({
-    accessToken: body.access_token,
-    expiresAt: body.expires_in ? Date.now() + (body.expires_in * 1000) : null,
-    refreshToken: body.refresh_token ?? null,
-  }));
 
 }
 

--- a/src/client/authorization-code.ts
+++ b/src/client/authorization-code.ts
@@ -1,4 +1,4 @@
-import { OAuth2Client, tokenResponseToOAuth2Token, generateQueryString } from '../client';
+import { OAuth2Client, generateQueryString } from '../client';
 import { OAuth2Token } from '../token';
 import { AuthorizationCodeRequest, AuthorizationQueryParams } from '../messages';
 import { OAuth2Error } from '../error';
@@ -142,7 +142,7 @@ export class OAuth2AuthorizationCodeClient {
       redirect_uri: params.redirectUri,
       code_verifier: params.codeVerifier,
     };
-    return tokenResponseToOAuth2Token(this.client.request('tokenEndpoint', body));
+    return this.client.tokenResponseToOAuth2Token(this.client.request('tokenEndpoint', body));
 
   }
 


### PR DESCRIPTION
Moved the `tokenResponseToOAuth2Token` function inside the OAuth2Client class, allowing users to override the parsing logic more easily.