### PR TITLE
Add support for extra params returned from token endpoint  (#1)

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -19,4 +19,9 @@ export type OAuth2Token = {
    * OAuth2 refresh token
    */
   refreshToken: string | null;
+
+  /**
+   * Any extra parameters returned by the server which were whitelisted.
+   */
+  extraParams: Record<string, any>;
 };

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -187,6 +187,7 @@ describe('authorization-code', () => {
 
       expect(result.accessToken).to.equal('access_token_000');
       expect(result.refreshToken).to.equal('refresh_token_000');
+      expect(result.extraParams).to.be.undefined;
       expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
       expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
 
@@ -199,6 +200,29 @@ describe('authorization-code', () => {
         redirect_uri: 'http://example/redirect',
       });
 
+    });
+
+
+    it('should should allow extra parameters to be returned with tokens', async() => {
+
+      const server = testServer();
+
+      const client = new OAuth2Client({
+        server: server.url,
+        tokenEndpoint: '/token',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        extraParams: ['foo']
+      });
+
+      const result = await client.authorizationCode.getToken({
+        code: 'code_000',
+        redirectUri: 'http://example/redirect',
+      });
+
+      expect(result.extraParams).not.to.be.undefined;
+      expect(result.extraParams?.foo).to.equal('bar_000');
+      expect(result.extraParams?.bar).to.be.undefined;
     });
 
     it('should should support PKCE', async() => {

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -62,6 +62,8 @@ const issueToken: Middleware = (ctx, next) => {
     access_token: 'access_token_000',
     refresh_token: 'refresh_token_000',
     expires_in: 3600,
+    foo: 'bar_000',
+    bar: 'foo_00'
   };
 
 };


### PR DESCRIPTION
Hello,

A provider we're using passed additional parameters during the code exchange that we needed to grab, so I added support for it to the package. Please let me know if you'd like me to make any udpates.

Thanks,
Ben