### PR TITLE
Setting the 'Accept' header on token requests.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.4.1 (????-??-??)
+------------------
+
+* #151: Add 'Accept' header on token requests to fix a Github compatibility
+  issue.
+
+
 2.4.0 (2024-07-27)
 ------------------
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -375,6 +375,9 @@ export class OAuth2Client {
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/x-www-form-urlencoded',
+      // Although it shouldn't be needed, Github OAUth2 will return JSON
+      // unless this is set.
+      'Accept': 'application/json',
     };
 
     let authMethod = this.settings.authenticationMethod;
@@ -447,11 +450,13 @@ export class OAuth2Client {
    */
   tokenResponseToOAuth2Token(resp: Promise<TokenResponse>): Promise<OAuth2Token> {
 
-    return resp.then(body => ({
-      accessToken: body.access_token,
-      expiresAt: body.expires_in ? Date.now() + (body.expires_in * 1000) : null,
-      refreshToken: body.refresh_token ?? null,
-    }));
+    return resp.then(body => {
+      return {
+        accessToken: body.access_token,
+        expiresAt: body.expires_in ? Date.now() + (body.expires_in * 1000) : null,
+        refreshToken: body.refresh_token ?? null,
+      };
+    });
 
   }
 

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -182,6 +182,7 @@ describe('authorization-code', () => {
 
       const request = server.lastRequest();
       expect(request.headers.get('Authorization')).to.equal(null);
+      expect(request.headers.get('Accept')).to.equal('application/json');
 
       expect(request.body).to.eql({
         client_id: 'test-client-id',
@@ -215,6 +216,7 @@ describe('authorization-code', () => {
 
       const request = server.lastRequest();
       expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
+      expect(request.headers.get('Accept')).to.equal('application/json');
 
       expect(request.body).to.eql({
         grant_type: 'authorization_code',
@@ -248,6 +250,7 @@ describe('authorization-code', () => {
 
       const request = server.lastRequest();
       expect(request.headers.get('Authorization')).to.equal(null);
+      expect(request.headers.get('Accept')).to.equal('application/json');
 
       expect(request.body).to.eql({
         client_id: 'test-client-id',
@@ -281,6 +284,7 @@ describe('authorization-code', () => {
 
       const request = server.lastRequest();
       expect(request.headers.get('Authorization')).to.equal(null);
+      expect(request.headers.get('Accept')).to.equal('application/json');
 
       expect(request.body).to.eql({
         client_id: 'test-client-id',
@@ -315,6 +319,7 @@ describe('authorization-code', () => {
 
       const request = server.lastRequest();
       expect(request.headers.get('Authorization')).to.equal(null);
+      expect(request.headers.get('Accept')).to.equal('application/json');
 
       expect(request.body).to.eql({
         client_id: 'test-client-id',

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -53,6 +53,7 @@ describe('client-credentials', () => {
 
     const request = server.lastRequest();
     expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
+    expect(request.headers.get('Accept')).to.equal('application/json');
 
     expect(request.body).to.eql({
       grant_type: 'client_credentials',

--- a/test/password.ts
+++ b/test/password.ts
@@ -27,6 +27,7 @@ describe('password', () => {
 
     const request = server.lastRequest();
     expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
+    expect(request.headers.get('Accept')).to.equal('application/json');
 
     expect(request.body).to.eql({
       grant_type: 'password',


### PR DESCRIPTION
By default Github will return urlencoded data when doing requests on the
token endpoint. Setting this accept header ensures we're getting JSON
back.

This is non-standard, but there's no harm.

See #151
