### PR TITLE
Implement JWT Bearer grant

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,7 @@ import {
   IntrospectionRequest,
   IntrospectionResponse,
   PasswordRequest,
+  JwtBearerRequest,
   OAuth2TokenTypeHint,
   RefreshRequest,
   RevocationRequest,
@@ -40,6 +41,15 @@ type PasswordParams = {
    */
   resource?: string | string[];
 
+}
+
+type JwtBearerParams = {
+  /**
+   * The JSON Web Token to use for the JWT Bearer token request.
+   */
+  assertion: string;
+
+  scope?: string[];
 }
 
 /**
@@ -79,8 +89,8 @@ export interface ClientSettings {
    * OAuth2 clientSecret
    *
    * This is required when using the 'client_secret_basic' authenticationMethod
-   * for the client_credentials and password flows, but not authorization_code
-   * or implicit.
+   * for the client_credentials and password flows, but not authorization_code,
+   * implicit or JWT Bearer.
    */
   clientSecret?: string;
 
@@ -226,6 +236,19 @@ export class OAuth2Client {
   }
 
   /**
+   * Retrieves an OAuth2 token using the 'urn:ietf:params:oauth:grant-type:jwt-bearer' grant.
+   */
+  async jwtBearer(params: JwtBearerParams): Promise<OAuth2Token> {
+
+    const body: JwtBearerRequest = {
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: params.assertion,
+      scope: params.scope?.join(' '),
+    };
+    return this.tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
+  }
+
+  /**
    * Returns the helper object for the `authorization_code` grant.
    */
   get authorizationCode(): OAuth2AuthorizationCodeClient {
@@ -366,7 +389,7 @@ export class OAuth2Client {
   /**
    * Does a HTTP request on the 'token' endpoint.
    */
-  async request(endpoint: 'tokenEndpoint', body: RefreshRequest | ClientCredentialsRequest | PasswordRequest | AuthorizationCodeRequest): Promise<TokenResponse>;
+  async request(endpoint: 'tokenEndpoint', body: RefreshRequest | ClientCredentialsRequest | PasswordRequest | JwtBearerRequest | AuthorizationCodeRequest): Promise<TokenResponse>;
   async request(endpoint: 'introspectionEndpoint', body: IntrospectionRequest): Promise<IntrospectionResponse>;
   async request(endpoint: 'revocationEndpoint', body: RevocationRequest): Promise<void>;
   async request(endpoint: OAuth2Endpoint, body: Record<string, any>): Promise<unknown> {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -50,6 +50,15 @@ export type PasswordRequest = {
   resource?: string | string[];
 }
 
+/**
+ * JWT Bearer Grant Type request body
+ */
+export type JwtBearerRequest = {
+  grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+  assertion: string;
+  scope?: string;
+}
+
 export type AuthorizationCodeRequest = {
   grant_type: 'authorization_code';
   code: string;

--- a/test/jwt-bearer.ts
+++ b/test/jwt-bearer.ts
@@ -1,0 +1,39 @@
+import { testServer } from './test-server';
+import { OAuth2Client } from '../src';
+import { expect } from 'chai';
+
+describe('jwt-bearer', () => {
+
+  it('should work with client_secret_post', async () => {
+
+    const server = testServer();
+
+    const client = new OAuth2Client({
+      server: server.url,
+      tokenEndpoint: '/token',
+      clientId: 'test-client-id',
+    });
+
+    const result = await client.jwtBearer({
+      assertion: 'foobar',
+      scope: ['hello', 'world']
+    });
+
+    expect(result.accessToken).to.equal('access_token_000');
+    expect(result.refreshToken).to.equal('refresh_token_000');
+    expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+    expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+    const request = server.lastRequest();
+    expect(request.headers.get('Authorization')).to.be.null;
+    expect(request.headers.get('Accept')).to.equal('application/json');
+
+    expect(request.body).to.eql({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: 'foobar',
+      scope: 'hello world',
+      client_id: 'test-client-id'
+    });
+  });
+
+});


### PR DESCRIPTION
This is a work-in-progress to implement the JWT Bearer grant type (which is needed in server-to-server setups, for example with Google APIs).

See: https://developers.google.com/identity/protocols/oauth2/service-account#httprest

This implementation adds the `jsonwebtoken` package as a dependency, which is probably not okay... Maybe the JWT could be generated outside of the library?