### PR TITLE
Re-use old refresh token if no new one was issued.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'version-2.x' ]
 
 jobs:
   test:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.4.2 (????-??-??)
+------------------
+
+* #161: Re-use old refresh_token if no new one was issued after a refresh.
+
+
 2.4.1 (2024-08-22)
 ------------------
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,7 +181,12 @@ export class OAuth2Client {
     if (params?.scope) body.scope = params.scope.join(' ');
     if (params?.resource) body.resource = params.resource;
 
-    return this.tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
+    const newToken = await this.tokenResponseToOAuth2Token(this.request('tokenEndpoint', body));
+    if (!newToken.refreshToken && token.refreshToken) {
+      // Reuse old refresh token if we didn't get a new one.
+      newToken.refreshToken = token.refreshToken;
+    }
+    return newToken;
 
   }
 

--- a/test/refresh.ts
+++ b/test/refresh.ts
@@ -1,0 +1,70 @@
+import { testServer } from './test-server';
+import { OAuth2Client } from '../src';
+import { expect } from 'chai';
+
+describe('refreshing tokens', () => {
+
+  it('should work', async () => {
+
+    const server = testServer();
+
+    const client = new OAuth2Client({
+      server: server.url,
+      tokenEndpoint: '/token',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    });
+
+    const result = await client.refreshToken({
+      refreshToken: 'refresh_token_000',
+      accessToken: 'access_token_000',
+      expiresAt: null,
+    });
+
+    expect(result.accessToken).to.equal('access_token_001');
+    expect(result.refreshToken).to.equal('refresh_token_001');
+    expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+    expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+    const request = server.lastRequest();
+    expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
+    expect(request.headers.get('Accept')).to.equal('application/json');
+
+    expect(request.body).to.eql({
+      grant_type: 'refresh_token',
+      refresh_token: 'refresh_token_000',
+    });
+  });
+
+  it('should re-use the old refresh token if no new one was issued', async () => {
+
+    const server = testServer();
+
+    const client = new OAuth2Client({
+      server: server.url,
+      tokenEndpoint: '/token',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    });
+
+    const result = await client.refreshToken({
+      refreshToken: 'refresh_token_001',
+      accessToken: 'access_token_001',
+      expiresAt: null,
+    });
+
+    expect(result.accessToken).to.equal('access_token_002');
+    expect(result.refreshToken).to.equal('refresh_token_001');
+    expect(result.expiresAt).to.be.lessThanOrEqual(Date.now() + 3600_000);
+    expect(result.expiresAt).to.be.greaterThanOrEqual(Date.now() + 3500_000);
+
+    const request = server.lastRequest();
+    expect(request.headers.get('Authorization')).to.equal('Basic ' + btoa('test-client-id:test-client-secret'));
+    expect(request.headers.get('Accept')).to.equal('application/json');
+
+    expect(request.body).to.eql({
+      grant_type: 'refresh_token',
+      refresh_token: 'refresh_token_001',
+    });
+  });
+});

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -105,11 +105,29 @@ const issueToken: Middleware = (ctx, next) => {
   }
 
   ctx.response.type = 'application/json';
-  ctx.response.body = {
-    access_token: 'access_token_000',
-    refresh_token: 'refresh_token_000',
-    expires_in: 3600,
-  };
+  if (ctx.request.body.refresh_token === 'refresh_token_000') {
+
+    ctx.response.body = {
+      access_token: 'access_token_001',
+      refresh_token: 'refresh_token_001',
+      expires_in: 3600,
+    };
+
+  } else if (ctx.request.body.refresh_token === 'refresh_token_001') {
+
+    ctx.response.body = {
+      access_token: 'access_token_002',
+      expires_in: 3600,
+    };
+
+  } else {
+
+    ctx.response.body = {
+      access_token: 'access_token_000',
+      refresh_token: 'refresh_token_000',
+      expires_in: 3600,
+    };
+  }
 
 };
 


### PR DESCRIPTION
Fixes #161
