### PR TITLE
Allow users to specify authorization response_type in OAuth2AuthorizationCodeClient

### DIFF
--- a/src/client/authorization-code.ts
+++ b/src/client/authorization-code.ts
@@ -40,6 +40,11 @@ type GetAuthorizeUrlParams = {
   extraParams?: Record<string, string>;
 
   /**
+   * The authorization grant type being requested. Defaults to 'code'.
+   */
+  responseType?: string;
+
+  /**
    * By default response parameters for the authorization_flow will be added
    * to the query string.
    *
@@ -110,7 +115,7 @@ export class OAuth2AuthorizationCodeClient {
 
     const query = new URLSearchParams({
       client_id: this.client.settings.clientId,
-      response_type: 'code',
+      response_type: params.responseType || 'code',
       redirect_uri: params.redirectUri,
     });
     if (codeChallenge) {


### PR DESCRIPTION
This PR adds support for specifying the response_type parameter in the OAuth2AuthorizationCodeClient. This allows users to customize the authorization flow, defaulting to 'code' if not provided.

Changes:
- Added an optional responseType field in GetAuthorizeUrlParams.
- Modified the OAuth2 query construction to use the provided responseType or default to 'code'.

Motivation:
Apple’s Sign in with Apple allows using a response_type of both 'code' and 'id_token' for authorization, requiring this flexibility in OAuth2 authorization flows.