### PR TITLE
Throw error when SubtleCrypto is used in an insecure context

### DIFF
--- a/src/client/authorization-code.ts
+++ b/src/client/authorization-code.ts
@@ -226,10 +226,15 @@ export async function getCodeChallenge(codeVerifier: string): Promise<['plain' |
   return ['S256', base64Url(await webCrypto.subtle.digest('SHA-256', stringToBuffer(codeVerifier)))];
 }
 
-async function getWebCrypto(): Promise<typeof window.crypto> {
+async function getWebCrypto(): Promise<typeof window.crypto> | never {
 
   // Browsers
   if ((typeof window !== 'undefined' && window.crypto)) {
+    if (!window.crypto.subtle?.digest) {
+      throw new Error(
+        "The context/environment is not secure, and does not support the 'crypto.subtle' module. See: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle for details"
+      );
+    }
     return window.crypto;
   }
   // Web workers possibly

--- a/src/client/authorization-code.ts
+++ b/src/client/authorization-code.ts
@@ -226,7 +226,7 @@ export async function getCodeChallenge(codeVerifier: string): Promise<['plain' |
   return ['S256', base64Url(await webCrypto.subtle.digest('SHA-256', stringToBuffer(codeVerifier)))];
 }
 
-async function getWebCrypto(): Promise<typeof window.crypto> | never {
+async function getWebCrypto(): Promise<typeof window.crypto> {
 
   // Browsers
   if ((typeof window !== 'undefined' && window.crypto)) {


### PR DESCRIPTION
This fixes #144 

It will throw an error when SubtleCrypto is not available, I.e. used in an insecure context.

I'm not sure how to add tests for this, as I'm not familiar with node:test and it does not seems to be a way to mock the `window` object.