### PR TITLE
Fix encoding of client id and secret in HTTP Basic

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -402,8 +402,11 @@ export class OAuth2Client {
 
     switch(authMethod) {
       case 'client_secret_basic' :
+        // Per RFC 6749 section 2.3.1, the client_id and client_secret need
+        // to be encoded using application/x-www-form-urlencoded for the
+        // basic auth.
         headers.Authorization = 'Basic ' +
-          btoa(this.settings.clientId + ':' + this.settings.clientSecret);
+          btoa(encodeURIComponent(this.settings.clientId) + ':' + encodeURIComponent(this.settings.clientSecret!));
         break;
       case 'client_secret_post' :
         body.client_id = this.settings.clientId;

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -18,8 +18,8 @@ describe('client-credentials', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
-      clientSecret: 'test-client-secret',
+      clientId: 'test-client-id:10',
+      clientSecret: 'test=client=secret',
     });
 
     const result = await client.clientCredentials();
@@ -32,7 +32,7 @@ describe('client-credentials', () => {
     const request = server.lastRequest();
     assert.equal(
       request.headers.get('Authorization'),
-      'Basic ' + btoa('test-client-id:test-client-secret')
+      'Basic ' + btoa('test-client-id%3A10:test%3Dclient%3Dsecret')
     );
 
     assert.deepEqual(request.body, {


### PR DESCRIPTION
Per https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1 the parameters first need to be url encoded.