### PR TITLE
Apply the most strict interpretation for Basic Auth encoding

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -406,7 +406,7 @@ export class OAuth2Client {
         // to be encoded using application/x-www-form-urlencoded for the
         // basic auth.
         headers.Authorization = 'Basic ' +
-          btoa(encodeURIComponent(this.settings.clientId) + ':' + encodeURIComponent(this.settings.clientSecret!));
+          btoa(legacyFormUrlEncode(this.settings.clientId) + ':' + legacyFormUrlEncode(this.settings.clientSecret!));
         break;
       case 'client_secret_post' :
         body.client_id = this.settings.clientId;
@@ -497,4 +497,16 @@ export function generateQueryString(params: Record<string, undefined | number | 
   }
   return query.toString();
 
+}
+
+/**
+ * Encodes string according to the most strict interpretation of RFC 6749 Appendix B.
+ *
+ * All non-alphanumeric characters are percent encoded, with exception of space which
+ * is replaced with '+'.
+ */
+export function legacyFormUrlEncode(value: string): string {
+  return encodeURIComponent(value)
+    .replace(/%20/g, '+')
+    .replace(/[-_.!~*'()]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
 }

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -195,8 +195,8 @@ describe('authorization-code', () => {
       const client = new OAuth2Client({
         server: server.url,
         tokenEndpoint: '/token',
-        clientId: 'test-client-id',
-        clientSecret: 'test-client-secret',
+        clientId: 'testClientId',
+        clientSecret: 'testClientSecret',
       });
 
       const result = await client.authorizationCode.getToken({
@@ -212,7 +212,7 @@ describe('authorization-code', () => {
       const request = server.lastRequest();
       assert.equal(
         request.headers.get('Authorization'),
-        'Basic ' + btoa('test-client-id:test-client-secret')
+        'Basic ' + btoa('testClientId:testClientSecret')
       );
       assert.equal(request.headers.get('Accept'), 'application/json');
 

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -18,7 +18,7 @@ describe('client-credentials', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id:10',
+      clientId: 'testClientId:10',
       clientSecret: 'test=client=secret',
     });
 
@@ -32,7 +32,7 @@ describe('client-credentials', () => {
     const request = server.lastRequest();
     assert.equal(
       request.headers.get('Authorization'),
-      'Basic ' + btoa('test-client-id%3A10:test%3Dclient%3Dsecret')
+      'Basic ' + btoa('testClientId%3A10:test%3Dclient%3Dsecret')
     );
 
     assert.deepEqual(request.body, {
@@ -45,8 +45,8 @@ describe('client-credentials', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
-      clientSecret: 'test-client-secret',
+      clientId: 'testClientId',
+      clientSecret: 'testClientSecret',
     });
 
     const result = await client.clientCredentials({
@@ -63,7 +63,7 @@ describe('client-credentials', () => {
     const request = server.lastRequest();
     assert.equal(
       request.headers.get('Authorization'),
-      'Basic ' + btoa('test-client-id:test-client-secret')
+      'Basic ' + btoa('testClientId:testClientSecret')
     );
     assert.equal(request.headers.get('Accept'), 'application/json');
 
@@ -79,8 +79,8 @@ describe('client-credentials', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
-      clientSecret: 'test-client-secret',
+      clientId: 'testClientId',
+      clientSecret: 'testClientSecret',
       authenticationMethod: 'client_secret_post',
     });
 
@@ -94,8 +94,8 @@ describe('client-credentials', () => {
     const request = server.lastRequest();
 
     assert.deepEqual(request.body, {
-      client_id: 'test-client-id',
-      client_secret: 'test-client-secret',
+      client_id: 'testClientId',
+      client_secret: 'testClientSecret',
       grant_type: 'client_credentials',
     });
   });
@@ -105,8 +105,8 @@ describe('client-credentials', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
-      clientSecret: 'test-client-secret',
+      clientId: 'testClientId',
+      clientSecret: 'testClientSecret',
     });
 
     const resource = ['https://example/resource1', 'https://example/resource2'];
@@ -123,7 +123,7 @@ describe('client-credentials', () => {
     const request = server.lastRequest();
     assert.equal(
       request.headers.get('Authorization'),
-      'Basic ' + btoa('test-client-id:test-client-secret')
+      'Basic ' + btoa('testClientId:testClientSecret')
     );
 
     assert.deepEqual(request.body, {
@@ -140,7 +140,7 @@ describe('client-credentials', () => {
         server: server.url,
         tokenEndpoint: '/token',
         clientId: 'oauth2-error',
-        clientSecret: 'test-client-secret',
+        clientSecret: 'testClientSecret',
         authenticationMethod: 'client_secret_post',
       });
 
@@ -171,7 +171,7 @@ describe('client-credentials', () => {
         server: server.url,
         tokenEndpoint: '/token',
         clientId: 'json-error',
-        clientSecret: 'test-client-secret',
+        clientSecret: 'testClientSecret',
         authenticationMethod: 'client_secret_post',
       });
 
@@ -204,7 +204,7 @@ describe('client-credentials', () => {
         server: server.url,
         tokenEndpoint: '/token',
         clientId: 'general-http-error',
-        clientSecret: 'test-client-secret',
+        clientSecret: 'testClientSecret',
         authenticationMethod: 'client_secret_post',
       });
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert';
 import { OAuth2Client } from '../src/index.js';
+import { legacyFormUrlEncode } from '../src/client.js';
 import { describe, it } from 'node:test';
 
 describe('tokenResponseToOAuth2Token', () => {
@@ -56,5 +57,14 @@ describe('tokenResponseToOAuth2Token', () => {
     }
 
     assert.equal(caught, true);
+  });
+});
+
+describe('legacyFormUrlEncode', () => {
+  it('correctly encodes full character set', () => {
+    const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ ó';
+    assert.equal(
+      legacyFormUrlEncode(chars),
+      '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E%5F%60%7B%7C%7D%7E+%C3%B3');
   });
 });

--- a/test/password.ts
+++ b/test/password.ts
@@ -18,8 +18,8 @@ describe('password', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
-      clientSecret: 'test-client-secret',
+      clientId: 'testClientId',
+      clientSecret: 'testClientSecret',
     });
 
     const result = await client.password({
@@ -35,7 +35,7 @@ describe('password', () => {
     const request = server.lastRequest();
     assert.equal(
       request.headers.get('Authorization'),
-      'Basic ' + btoa('test-client-id:test-client-secret')
+      'Basic ' + btoa('testClientId:testClientSecret')
     );
     assert.equal(request.headers.get('Accept'), 'application/json');
 
@@ -52,7 +52,7 @@ describe('password', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
+      clientId: 'testClientId',
       authenticationMethod: 'client_secret_post',
     });
 
@@ -72,7 +72,7 @@ describe('password', () => {
       grant_type: 'password',
       password: 'password',
       username: 'user123',
-      client_id: 'test-client-id',
+      client_id: 'testClientId',
     });
   });
 
@@ -82,7 +82,7 @@ describe('password', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
+      clientId: 'testClientId',
       authenticationMethod: 'client_secret_post',
     });
     const resource = ['https://example/resource1', 'https://example/resource2'];
@@ -104,7 +104,7 @@ describe('password', () => {
       grant_type: 'password',
       password: 'password',
       username: 'user123',
-      client_id: 'test-client-id',
+      client_id: 'testClientId',
       resource,
     });
   });

--- a/test/refresh.ts
+++ b/test/refresh.ts
@@ -19,8 +19,8 @@ describe('refreshing tokens', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
-      clientSecret: 'test-client-secret',
+      clientId: 'testClientId',
+      clientSecret: 'testClientSecret',
     });
 
     const result = await client.refreshToken({
@@ -37,7 +37,7 @@ describe('refreshing tokens', () => {
     const request = server.lastRequest();
     assert.equal(
       request.headers.get('Authorization'),
-      'Basic ' + btoa('test-client-id:test-client-secret')
+      'Basic ' + btoa('testClientId:testClientSecret')
     );
     assert.equal(
       request.headers.get('Accept'),
@@ -57,8 +57,8 @@ describe('refreshing tokens', () => {
     const client = new OAuth2Client({
       server: server.url,
       tokenEndpoint: '/token',
-      clientId: 'test-client-id',
-      clientSecret: 'test-client-secret',
+      clientId: 'testClientId',
+      clientSecret: 'testClientSecret',
     });
 
     const result = await client.refreshToken({
@@ -75,7 +75,7 @@ describe('refreshing tokens', () => {
     const request = server.lastRequest();
     assert.equal(
       request.headers.get('Authorization'),
-      'Basic ' + btoa('test-client-id:test-client-secret')
+      'Basic ' + btoa('testClientId:testClientSecret')
     );
     assert.equal(
       request.headers.get('Accept'),


### PR DESCRIPTION
Amends 49d3241c13a442f8288d5dded80eaa33e5915ddb per discussion in https://github.com/badgateway/oauth2-client/pull/171 with the most strict interpretation of required encoding for the HTTP Basic Authentication user and password.