### PR TITLE
Add support for the OpenID connect id_token

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -465,11 +465,15 @@ export class OAuth2Client {
       throw new TypeError('We received an invalid token response from an OAuth2 server.');
     }
 
-    return {
+    const result: OAuth2Token = {
       accessToken: body.access_token,
       expiresAt: body.expires_in ? Date.now() + (body.expires_in * 1000) : null,
       refreshToken: body.refresh_token ?? null,
     };
+    if (body.id_token) {
+      result.idToken = body.id_token;
+    }
+    return result;
 
   }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -68,11 +68,36 @@ export type AuthorizationCodeRequest = {
  * Response from the /token endpoint
  */
 export type TokenResponse = {
+  /**
+   * The OAuth 2 access token.
+   */
   access_token: string;
+
+  /**
+   * The type of token, which is always "Bearer".
+   */
   token_type: string;
+
+  /**
+   * The lifetime in seconds of the access token.
+   */
   expires_in?: number;
+
+  /**
+   * The refresh token, which can be used to get a new access token after the current one expires.
+   */
   refresh_token?: string;
+
+  /**
+   * List of comma-separated scopes that the access token is valid for.
+   */
   scope?: string;
+
+  /**
+   * The OpenID Connect id_token, which is a JWT encoded value containing
+   * information about the authenticated user.
+   */
+  id_token?: string;
 }
 
 type OAuth2ResponseType = 'code' | 'token';

--- a/src/token.ts
+++ b/src/token.ts
@@ -19,4 +19,9 @@ export type OAuth2Token = {
    * OAuth2 refresh token
    */
   refreshToken: string | null;
+
+  /**
+   * OpenID Connect ID Token
+   */
+  idToken?: string;
 };

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -131,6 +131,26 @@ describe('client-credentials', () => {
       resource,
     });
   });
+  it('should return an idToken if it was returned from the server', async () => {
+    const client = new OAuth2Client({
+      clientId: 'foo',
+    });
+    const token = await client.tokenResponseToOAuth2Token(
+      Promise.resolve({
+        token_type: 'bearer',
+        access_token: 'foo',
+        id_token: 'bar',
+        refresh_token: 'baz',
+      })
+    );
+
+    assert.deepEqual(token, {
+      accessToken: 'foo',
+      idToken: 'bar',
+      expiresAt: null,
+      refreshToken: 'baz',
+    });
+  });
 
   describe('error handling', async () => {
     it('should create a OAuth2HttpError if an error was thrown', async () => {
@@ -225,5 +245,6 @@ describe('client-credentials', () => {
         assert.equal(err.parsedBody, undefined);
       }
     });
+
   });
 });


### PR DESCRIPTION
If a server returns an id_token, we're now exposing that information.

We're still not intending to be a full OpenID Connect client, but this is a relatively easy addition that a few people have asked for. 