### PR TITLE
Include additional properties from the token response

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -155,10 +155,10 @@ export interface ClientSettings {
   authenticationMethod?: 'client_secret_basic' | 'client_secret_post' | 'client_secret_basic_interop';
 
   /**
-    * Some providers return additional parameters during the token call.
-    * This flag allows to include all these properties in the `OAuth2Token`
-    * object, under the `additionalTokenProperties` property.
-    */
+   * Some OAuth2 servers return additional properties during the token call.
+   * This flag allows to include all these properties in the `OAuth2Token`
+   * object, under the `additionalProperties` property.
+   */
   tokenAdditionalProperties?: boolean;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -154,12 +154,6 @@ export interface ClientSettings {
    */
   authenticationMethod?: 'client_secret_basic' | 'client_secret_post' | 'client_secret_basic_interop';
 
-  /**
-   * Some OAuth2 servers return additional properties during the token call.
-   * This flag allows to include all these properties in the `OAuth2Token`
-   * object, under the `additionalProperties` property.
-   */
-  tokenAdditionalProperties?: boolean;
 }
 
 
@@ -501,7 +495,7 @@ export class OAuth2Client {
       refresh_token,
       expires_in,
       id_token,
-      ...additionalProperties
+      ...extraParams
     } = body;
 
     const result: OAuth2Token = {
@@ -512,8 +506,8 @@ export class OAuth2Client {
     if (id_token) {
       result.idToken = id_token;
     }
-    if(this.settings.tokenAdditionalProperties) {
-      result.additionalProperties = additionalProperties;
+    if(Object.keys(extraParams).length > 0) {
+      result.extraParams = extraParams;
     }
     return result;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -509,7 +509,7 @@ export class OAuth2Client {
       result.idToken = id_token;
     }
     if (scope) {
-      result.scopes = scope.split(' ');
+      result.scope = scope.split(' ');
     }
     if (Object.keys(extraParams).length > 0) {
       result.extraParams = extraParams;

--- a/src/client.ts
+++ b/src/client.ts
@@ -495,6 +495,8 @@ export class OAuth2Client {
       refresh_token,
       expires_in,
       id_token,
+      scope,
+      token_type,
       ...extraParams
     } = body;
 
@@ -506,7 +508,10 @@ export class OAuth2Client {
     if (id_token) {
       result.idToken = id_token;
     }
-    if(Object.keys(extraParams).length > 0) {
+    if (scope) {
+      result.scopes = scope.split(' ');
+    }
+    if (Object.keys(extraParams).length > 0) {
       result.extraParams = extraParams;
     }
     return result;

--- a/src/client.ts
+++ b/src/client.ts
@@ -154,6 +154,12 @@ export interface ClientSettings {
    */
   authenticationMethod?: 'client_secret_basic' | 'client_secret_post' | 'client_secret_basic_interop';
 
+  /**
+    * Some providers return additional parameters during the token call.
+    * This flag allows to include all these properties in the `OAuth2Token`
+    * object, under the `additionalTokenProperties` property.
+    */
+  tokenAdditionalProperties?: boolean;
 }
 
 
@@ -490,13 +496,24 @@ export class OAuth2Client {
       throw new TypeError('We received an invalid token response from an OAuth2 server.');
     }
 
+    const {
+      access_token,
+      refresh_token,
+      expires_in,
+      id_token,
+      ...additionalProperties
+    } = body;
+
     const result: OAuth2Token = {
-      accessToken: body.access_token,
-      expiresAt: body.expires_in ? Date.now() + (body.expires_in * 1000) : null,
-      refreshToken: body.refresh_token ?? null,
+      accessToken: access_token,
+      expiresAt: expires_in ? Date.now() + (expires_in * 1000) : null,
+      refreshToken: refresh_token ?? null,
     };
-    if (body.id_token) {
-      result.idToken = body.id_token;
+    if (id_token) {
+      result.idToken = id_token;
+    }
+    if(this.settings.tokenAdditionalProperties) {
+      result.additionalProperties = additionalProperties;
     }
     return result;
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -27,9 +27,6 @@ export type OAuth2Token = {
 
   /**
    * Additional tokens properties returned by the OAuth2 server.
-   *
-   * To include these properties, set `tokenAdditionalProperties`
-   * to true in the `ClientSettings` object.
    */
-  additionalProperties?: Record<string, any>;
+  extraParams?: Record<string, any>;
 };

--- a/src/token.ts
+++ b/src/token.ts
@@ -24,4 +24,12 @@ export type OAuth2Token = {
    * OpenID Connect ID Token
    */
   idToken?: string;
+
+  /**
+   * Additional tokens properties included by the OAuth2 server.
+   * 
+   * To include these properties, set `returnAdditionalTokenProperties`
+   * to true in the `ClientSettings` object.
+   */
+  additionalProperties?: Record<string, any>;
 };

--- a/src/token.ts
+++ b/src/token.ts
@@ -29,7 +29,7 @@ export type OAuth2Token = {
    * List of scopes that the access token is valid for.
    * (May be omitted if identical to the requested scope)
    */
-  scopes?: string[];
+  scope?: string[];
 
   /**
    * Additional tokens properties returned by the OAuth2 server.

--- a/src/token.ts
+++ b/src/token.ts
@@ -27,7 +27,7 @@ export type OAuth2Token = {
 
   /**
    * Additional tokens properties returned by the OAuth2 server.
-   * 
+   *
    * To include these properties, set `tokenAdditionalProperties`
    * to true in the `ClientSettings` object.
    */

--- a/src/token.ts
+++ b/src/token.ts
@@ -26,6 +26,12 @@ export type OAuth2Token = {
   idToken?: string;
 
   /**
+   * List of scopes that the access token is valid for.
+   * (May be omitted if identical to the requested scope)
+   */
+  scopes?: string[];
+
+  /**
    * Additional tokens properties returned by the OAuth2 server.
    */
   extraParams?: Record<string, any>;

--- a/src/token.ts
+++ b/src/token.ts
@@ -26,9 +26,9 @@ export type OAuth2Token = {
   idToken?: string;
 
   /**
-   * Additional tokens properties included by the OAuth2 server.
+   * Additional tokens properties returned by the OAuth2 server.
    * 
-   * To include these properties, set `returnAdditionalTokenProperties`
+   * To include these properties, set `tokenAdditionalProperties`
    * to true in the `ClientSettings` object.
    */
   additionalProperties?: Record<string, any>;

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -320,6 +320,26 @@ describe('authorization-code', () => {
         resource,
       });
     });
+    
+    it('should return additional token properties', async () => {
+      server = testServer();
+
+      const client = new OAuth2Client({
+        server: server.url,
+        tokenEndpoint: '/token',
+        clientId: 'test-client-id',
+        tokenAdditionalProperties: true
+      });
+
+      const result = await client.authorizationCode.getToken({
+        code: 'code_000',
+        redirectUri: 'http://example/redirect',
+      });
+
+      assert.deepEqual(result.additionalProperties, {
+        foo: 'bar',
+      });
+    });
   });
 
   describe('validateResponse', () => {

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -174,6 +174,7 @@ describe('authorization-code', () => {
 
       assert.equal(result.accessToken, 'access_token_000');
       assert.equal(result.refreshToken, 'refresh_token_000');
+      assert.deepEqual(result.scopes, ['foo', 'bar']);
       assert.deepEqual(result.extraParams, {
         foo: 'bar',
       });

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -174,6 +174,9 @@ describe('authorization-code', () => {
 
       assert.equal(result.accessToken, 'access_token_000');
       assert.equal(result.refreshToken, 'refresh_token_000');
+      assert.deepEqual(result.extraParams, {
+        foo: 'bar',
+      });
       assert.ok((result.expiresAt as number) <= Date.now() + 3600_000);
       assert.ok((result.expiresAt as number) >= Date.now() + 3500_000);
 
@@ -318,26 +321,6 @@ describe('authorization-code', () => {
         code: 'code_000',
         redirect_uri: 'http://example/redirect',
         resource,
-      });
-    });
-
-    it('should return additional token properties', async () => {
-      server = testServer();
-
-      const client = new OAuth2Client({
-        server: server.url,
-        tokenEndpoint: '/token',
-        clientId: 'test-client-id',
-        tokenAdditionalProperties: true
-      });
-
-      const result = await client.authorizationCode.getToken({
-        code: 'code_000',
-        redirectUri: 'http://example/redirect',
-      });
-
-      assert.deepEqual(result.additionalProperties, {
-        foo: 'bar',
       });
     });
   });

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -174,7 +174,7 @@ describe('authorization-code', () => {
 
       assert.equal(result.accessToken, 'access_token_000');
       assert.equal(result.refreshToken, 'refresh_token_000');
-      assert.deepEqual(result.scopes, ['foo', 'bar']);
+      assert.deepEqual(result.scope, ['foo', 'bar']);
       assert.deepEqual(result.extraParams, {
         foo: 'bar',
       });

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -320,7 +320,7 @@ describe('authorization-code', () => {
         resource,
       });
     });
-    
+
     it('should return additional token properties', async () => {
       server = testServer();
 

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -205,9 +205,6 @@ describe('client-credentials', () => {
       idToken: 'bar',
       expiresAt: null,
       refreshToken: 'baz',
-      extraParams: {
-        token_type: 'bearer'
-      }
     });
   });
 

--- a/test/client-credentials.ts
+++ b/test/client-credentials.ts
@@ -205,6 +205,9 @@ describe('client-credentials', () => {
       idToken: 'bar',
       expiresAt: null,
       refreshToken: 'baz',
+      extraParams: {
+        token_type: 'bearer'
+      }
     });
   });
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -19,6 +19,9 @@ describe('tokenResponseToOAuth2Token', () => {
       accessToken: 'foo-bar',
       expiresAt: null,
       refreshToken: null,
+      extraParams: {
+        token_type: 'bearer'
+      }
     });
   });
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -21,7 +21,7 @@ describe('tokenResponseToOAuth2Token', () => {
       accessToken: 'foo-bar',
       expiresAt: null,
       refreshToken: null,
-      scopes: ['foo', 'bar'],
+      scope: ['foo', 'bar'],
       extraParams: {
         foo: 'bar'
       }

--- a/test/client.ts
+++ b/test/client.ts
@@ -12,8 +12,8 @@ describe('tokenResponseToOAuth2Token', () => {
       Promise.resolve({
         token_type: 'bearer',
         access_token: 'foo-bar',
-        scope: "foo bar",
-        foo: "bar"
+        scope: 'foo bar',
+        foo: 'bar'
       })
     );
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -12,6 +12,8 @@ describe('tokenResponseToOAuth2Token', () => {
       Promise.resolve({
         token_type: 'bearer',
         access_token: 'foo-bar',
+        scope: "foo bar",
+        foo: "bar"
       })
     );
 
@@ -19,8 +21,9 @@ describe('tokenResponseToOAuth2Token', () => {
       accessToken: 'foo-bar',
       expiresAt: null,
       refreshToken: null,
+      scopes: ['foo', 'bar'],
       extraParams: {
-        token_type: 'bearer'
+        foo: 'bar'
       }
     });
   });

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -108,6 +108,7 @@ const issueToken: Middleware = (ctx, next) => {
   if (ctx.request.body.refresh_token === 'refresh_token_000') {
 
     ctx.response.body = {
+      token_type: 'Bearer',
       access_token: 'access_token_001',
       refresh_token: 'refresh_token_001',
       expires_in: 3600,
@@ -116,6 +117,7 @@ const issueToken: Middleware = (ctx, next) => {
   } else if (ctx.request.body.refresh_token === 'refresh_token_001') {
 
     ctx.response.body = {
+      token_type: 'Bearer',
       access_token: 'access_token_002',
       expires_in: 3600,
     };
@@ -123,9 +125,11 @@ const issueToken: Middleware = (ctx, next) => {
   } else {
 
     ctx.response.body = {
+      token_type: 'Bearer',
       access_token: 'access_token_000',
       refresh_token: 'refresh_token_000',
       expires_in: 3600,
+      scope: 'foo bar',
       foo: 'bar'  // Additional property returned by the server
     };
   }

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -126,6 +126,7 @@ const issueToken: Middleware = (ctx, next) => {
       access_token: 'access_token_000',
       refresh_token: 'refresh_token_000',
       expires_in: 3600,
+      foo: 'bar'  // Additional property returned by the server
     };
   }
 


### PR DESCRIPTION
Following the conversation on this PR: https://github.com/badgateway/oauth2-client/pull/133

I propose an implementation of the solution suggested by @evert.

IMO we could go even further and simply remove the `tokenAdditionalProperties` client setting. Are there cases in which including these additional properties would be a problem?