### PR TITLE
Preserve query params baked into the authorization endpoint

### DIFF
--- a/src/client/authorization-code.ts
+++ b/src/client/authorization-code.ts
@@ -137,7 +137,34 @@ export class OAuth2AuthorizationCodeClient {
       query.set(k, v);
     }
 
-    return authorizationEndpoint + '?' + query.toString();
+    // Fast path: endpoint has no baked query — plain concat, no URL
+    // allocation. This is the common case.
+    if (!authorizationEndpoint.includes('?')) {
+      return authorizationEndpoint + '?' + query.toString();
+    }
+
+    // Slow path: the endpoint already carries query parameters baked in
+    // via the provider's discovery document. Salesforce is the canonical
+    // example — its published `authorization_endpoint` is
+    // `.../oauth2/authorize?prompt=select_account`. A plain concat would
+    // produce a URL with two '?' separators; servers parse only the first
+    // as the query delimiter, so `client_id` ends up buried inside the
+    // `prompt` value and the request is rejected as `invalid_client_id`.
+    //
+    // Merge via URL so baked params survive and the library's runtime
+    // params win on collision — the authorization_code flow depends on
+    // canonical values like `response_type=code`. Two passes are
+    // intentional: folding into one would require an allocated Set to
+    // avoid re-deleting the value a previous iteration just appended for
+    // multi-valued keys like `resource`.
+    const url = new URL(authorizationEndpoint);
+    for (const key of query.keys()) {
+      url.searchParams.delete(key);
+    }
+    for (const [key, value] of query) {
+      url.searchParams.append(key, value);
+    }
+    return url.toString();
 
   }
 

--- a/test/authorization-code.ts
+++ b/test/authorization-code.ts
@@ -155,6 +155,72 @@ describe('authorization-code', () => {
         server.url + '/authorize?' + params.toString()
       );
     });
+    it('should preserve query parameters baked into the authorization endpoint', async () => {
+      // Real-world case: Salesforce's OAuth2 discovery document returns
+      // `authorization_endpoint` as `.../oauth2/authorize?prompt=select_account`.
+      // The library used to naively append `?` + query, producing a malformed
+      // URL with two `?` separators.
+      server = testServer();
+      const client = new OAuth2Client({
+        server: server.url,
+        authorizationEndpoint: '/authorize?prompt=select_account',
+        clientId: 'test-client-id',
+      });
+
+      const redirectUri = 'http://my-app.example/redirect';
+
+      const result = await client.authorizationCode.getAuthorizeUri({
+        redirectUri,
+      });
+
+      const resultUrl = new URL(result);
+      assert.equal(resultUrl.pathname, '/authorize');
+      assert.equal(resultUrl.searchParams.get('prompt'), 'select_account');
+      assert.equal(resultUrl.searchParams.get('client_id'), 'test-client-id');
+      assert.equal(resultUrl.searchParams.get('response_type'), 'code');
+      assert.equal(resultUrl.searchParams.get('redirect_uri'), redirectUri);
+      // Only one `?` in the final URL.
+      assert.equal((result.match(/\?/g) ?? []).length, 1);
+    });
+    it('should let runtime params override baked-in params on collision', async () => {
+      // Defensive: if a provider's discovery document bakes in a standard
+      // OAuth param the library also sets (e.g. `response_type=token`),
+      // the library's value must win — the authorization_code flow
+      // depends on `response_type=code`. Non-colliding baked params are
+      // preserved alongside.
+      server = testServer();
+      const client = new OAuth2Client({
+        server: server.url,
+        authorizationEndpoint: '/authorize?response_type=token&prompt=login',
+        clientId: 'test-client-id',
+      });
+
+      const result = await client.authorizationCode.getAuthorizeUri({
+        redirectUri: 'http://my-app.example/redirect',
+      });
+
+      const resultUrl = new URL(result);
+      assert.deepEqual(resultUrl.searchParams.getAll('response_type'), ['code']);
+      assert.equal(resultUrl.searchParams.get('prompt'), 'login');
+    });
+    it('should preserve multi-valued resource params alongside baked-in params', async () => {
+      server = testServer();
+      const client = new OAuth2Client({
+        server: server.url,
+        authorizationEndpoint: '/authorize?prompt=select_account',
+        clientId: 'test-client-id',
+      });
+
+      const resource = ['https://example/foo1', 'https://example/foo2'];
+      const result = await client.authorizationCode.getAuthorizeUri({
+        redirectUri: 'http://my-app.example/redirect',
+        resource,
+      });
+
+      const resultUrl = new URL(result);
+      assert.deepEqual(resultUrl.searchParams.getAll('resource'), resource);
+      assert.equal(resultUrl.searchParams.get('prompt'), 'select_account');
+    });
   });
 
   describe('Token endpoint calls', () => {


### PR DESCRIPTION
 ## Problem                                                                                                                                                 

  Some OAuth providers publish authorization endpoints with query parameters already embedded in their discovery documents. For example, Salesforce's          
  `.well-known` returns:
                                                                                                                                                               
  "authorization_endpoint": "https://login.salesforce.com/services/oauth2/authorize?prompt=select_account"                                                     
                                                                                                                                                             
  `getAuthorizeUri` does a naive concat:                                                                                                                       
                                                                                                 
  ```ts                                                                                                                                                      
  return authorizationEndpoint + '?' + query.toString();
                                                                                                                                                               
  …which produces a URL with two ? separators. Per RFC 3986 §3.4 only the first ? delimits the query, so client_id ends up parsed as part of the prompt value  
  and the server rejects the request (Salesforce returns invalid_client_id).                                                                                   
                                                                                                                                                               
  Fix                                                                                                                                                        
                                                                                                                                                             
  - Fast path — endpoint has no baked query: plain concat, no URL allocation. Byte-identical to current behavior.                                              
  - Slow path — endpoint has a baked query: merge via URL. Baked params survive; runtime params win on key collision (authorization_code flow depends on
  response_type=code); multi-valued keys like resource are preserved via append.                                                                               
                                                                                                 
  Two loops in the slow path are intentional — folding into one would require an allocated Set to avoid re-deleting a value a previous iteration just appended.
                                                                                                 
  Tests                                                                                                                                                        
                                                                                                 
  Three new cases in test/authorization-code.ts:                                                                                                               
  1. Baked prompt=select_account is preserved alongside library params.
  2. Runtime params override colliding baked params.                                                                                                           
  3. Multi-valued resource survives alongside a baked param.                                     
                                                                                                                                                               
  48/48 tests pass, lint + build clean. No public API change.